### PR TITLE
use ModuleFile when provided

### DIFF
--- a/src/main/java/com/inductiveautomation/ignitionsdk/PostModuleMojo.java
+++ b/src/main/java/com/inductiveautomation/ignitionsdk/PostModuleMojo.java
@@ -63,8 +63,13 @@ public class PostModuleMojo extends AbstractMojo {
             getLog().debug("Attempting to load the following path: ");
 
             Path buildPath = Paths.get(project.getBuild().getDirectory());
-            String modulePath = buildPath.toAbsolutePath() + File.separator +
+            String modulePath;
+                
+            if(this.moduleFile == null)
+                modulePath = buildPath.toAbsolutePath() + File.separator +
                     StringUtils.replace(moduleName, ' ', '-') + "-unsigned.modl";
+            else
+                modulePath = this.moduleFile.getPath();
 
             getLog().info("Installing " + modulePath + " to gateway.");
 


### PR DESCRIPTION
Hi,

Is it possible to merge this PR in order to use moduleFile when provided in pom.xml.  Now it only posts to the gateway when the modulename uses yyyyyyyy-unsigned.modl filename.

Kind regards,