### PR TITLE
fix: Get artifact id instead of name

### DIFF
--- a/src/main/java/com/inductiveautomation/ignitionsdk/IgnitionModlMojo.java
+++ b/src/main/java/com/inductiveautomation/ignitionsdk/IgnitionModlMojo.java
@@ -164,7 +164,7 @@ public class IgnitionModlMojo extends AbstractMojo {
         }
 
         for (MavenProject p : parent.getCollectedProjects()) {
-            String ignitionScope = ignitionScopes.get(p.getName());
+            String ignitionScope = ignitionScopes.get(p.getArtifactId());
 
             getLog().info(String.format("project=%s, ignitionScope=%s", p.getName(), ignitionScope));
 


### PR DESCRIPTION
Found an issue with the documentation which mentions that the artifact id is used when defining the project scopes.
![image](https://github.com/user-attachments/assets/7fd75381-4aef-4c78-8973-75bc7d9efa27)

But the name property of the artifact is used instead.
