### PR TITLE
Create dev module descriptor for IDE classloader isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,71 @@ This is the maven plugin used in the Ignition SDK examples to build Ignition Mod
 
 Check out the repo, and execute `mvn clean install`
 
+# Goals
+
+## `ignition:modl`
+
+Builds the `.modl` file from the configured module structure. This is the primary goal, bound to the `package` phase by default.
+
+## `ignition:post`
+
+POSTs a built `.modl` file to a running Ignition Gateway for hot deployment during development.
+
+## `ignition:write-dev-descriptor`
+
+Generates a JSON dev module descriptor for IDE classloader isolation. Bound to the `compile` phase by default.
+
+The descriptor enables a dev Ignition gateway to load your module directly from Maven build outputs (`target/classes` + resolved dependency JARs) instead of requiring a full `.modl` build. This provides:
+
+- **Classloader isolation** matching production behavior (each module gets its own `ModuleClassLoader`)
+- **HotSwap support** for method-body changes via JDWP
+- **No .modl build required** — no compile+zip+sign cycle for code changes
+
+### Usage
+
+```bash
+mvn ignition:write-dev-descriptor
+```
+
+This produces `target/dev/{moduleId}.json`. Copy it to your gateway's `user-lib/modules/dev/` directory:
+
+```bash
+mkdir -p /path/to/ignition/user-lib/modules/dev
+cp target/dev/*.json /path/to/ignition/user-lib/modules/dev/
+```
+
+### Gateway Configuration
+
+Your dev gateway needs these JVM flags in `ignition.conf` (or wrapper config):
+
+```
+# Required: allow unsigned modules
+-Dignition.allowunsignedmodules=true
+
+# Required: point gateway at dev descriptor directory
+-Dignition.dev.moduleDir=user-lib/modules/dev
+
+# Recommended: enable remote debugging for breakpoints + HotSwap
+-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
+```
+
+> **Note:** These flags only activate on **dev builds** of Ignition. The dev module loading path is completely inert on production gateways.
+
+### Development Workflow
+
+1. `mvn compile` then `mvn ignition:write-dev-descriptor` — generate and copy descriptor (first time, or after dependency changes)
+2. Start/restart the gateway
+3. In IntelliJ: **Run → Attach to Process** (or create a **Remote JVM Debug** config on port 5005)
+4. Make code changes
+5. **Build → Recompile** (Ctrl+Shift+F9 / Cmd+Shift+F9) — HotSwap applies method-body changes immediately
+6. Test in the browser — changes are live
+
+Repeat steps 4-6 without restarting. Only restart the gateway when:
+- Module dependencies change (added/removed/version bumped)
+- Module metadata changes (hooks, module dependencies)
+- Structural class changes that HotSwap can't handle (new methods, new fields)
+
+### Configuration
+
+The goal reads the same `<configuration>` block as `ignition:modl` — no additional configuration is needed. It uses `moduleId`, `moduleName`, `moduleVersion`, `projectScopes`, `hooks`, and `depends` to build the descriptor, and resolves compile-scope dependencies from each sub-project.
+

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ The descriptor enables a dev Ignition gateway to load your module directly from 
 - **HotSwap support** for method-body changes via JDWP
 - **No .modl build required** — no compile+zip+sign cycle for code changes
 
+> For Gradle-based modules, the [`ignition-module-tools`](https://github.com/inductiveautomation/ignition-module-tools) Gradle plugin provides the equivalent `writeDevModuleDescriptor` task, which emits the same descriptor format.
+
 ### Usage
 
 ```bash
@@ -72,5 +74,24 @@ Repeat steps 4-6 without restarting. Only restart the gateway when:
 
 ### Configuration
 
-The goal reads the same `<configuration>` block as `ignition:modl` — no additional configuration is needed. It uses `moduleId`, `moduleName`, `moduleVersion`, `projectScopes`, `hooks`, and `depends` to build the descriptor, and resolves compile-scope dependencies from each sub-project.
+The goal reads the same `<configuration>` block as [`ignition:modl`](#ignitionmodl) — no additional configuration is needed. It uses `moduleId`, `moduleName`, `moduleVersion`, `requiredIgnitionVersion`, `projectScopes`, `hooks`, and `depends` to build the descriptor, and resolves compile-scope dependencies from each sub-project.
+
+`<projectScopes>` maps each sub-project to the Ignition scope(s) it targets. The `<name>` is matched against the `<name>` element of the child module's POM (not its `<artifactId>`), and `<scope>` is one or more Ignition scope letters — `G` (gateway), `C` (client/vision), `D` (designer):
+
+```xml
+<projectScopes>
+    <projectScope>
+        <name>my-module-gateway</name>   <!-- matches <name> in the child pom -->
+        <scope>G</scope>
+    </projectScope>
+    <projectScope>
+        <name>my-module-designer</name>
+        <scope>CD</scope>                <!-- may combine scopes -->
+    </projectScope>
+</projectScopes>
+```
+
+The `required` flag on a `<depend>` is only written to the descriptor (and to `module.xml`) when `requiredIgnitionVersion` is 8.3 or newer, since earlier gateways don't understand it. It defaults to `false`.
+
+> **Portability:** the descriptor bakes in absolute filesystem paths (class directories and dependency JARs) specific to the machine that generated it. Regenerate it on each dev machine — **do not check it into source control.**
 

--- a/README.md
+++ b/README.md
@@ -30,11 +30,23 @@ The descriptor enables a dev Ignition gateway to load your module directly from 
 
 ### Usage
 
-```bash
-mvn ignition:write-dev-descriptor
+Bind the goal in your module's build POM (alongside `ignition:modl`) so it runs as part of the normal build:
+
+```xml
+<execution>
+    <phase>package</phase>
+    <goals>
+        <goal>modl</goal>
+        <goal>write-dev-descriptor</goal>
+    </goals>
+</execution>
 ```
 
-This produces `target/dev/{moduleId}.json`. Copy it to your gateway's `user-lib/modules/dev/` directory:
+Then `mvn package` produces `target/dev/{moduleId}.json`.
+
+> **Run it through the phase binding (`mvn package`), not as a direct `mvn ignition:write-dev-descriptor` invocation.** A directly-invoked goal executes against every module in the reactor: at an aggregator root it hits the parent POM, which lacks the required `<configuration>` and fails with "parameters … are missing or invalid"; restricting with `-pl <build-module>` instead drops the sibling gateway module from the reactor, so its inter-module `SNAPSHOT` dependency can't be resolved and the build fails there. The phase binding above avoids both problems by running the goal on the correct module as part of the normal reactor build.
+
+Copy the descriptor to your gateway's `user-lib/modules/dev/` directory:
 
 ```bash
 mkdir -p /path/to/ignition/user-lib/modules/dev
@@ -60,7 +72,7 @@ Your dev gateway needs these JVM flags in `ignition.conf` (or wrapper config):
 
 ### Development Workflow
 
-1. `mvn compile` then `mvn ignition:write-dev-descriptor` — generate and copy descriptor (first time, or after dependency changes)
+1. `mvn package` — build the module and generate the descriptor, then copy it (first time, or after dependency changes)
 2. Start/restart the gateway
 3. In IntelliJ: **Run → Attach to Process** (or create a **Remote JVM Debug** config on port 5005)
 4. Make code changes

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,11 @@
             <version>1.8</version>
             <type>jar</type>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
+        </dependency>
 
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,8 @@
             <version>1.8</version>
             <type>jar</type>
         </dependency>
+        <!-- Used by ignition:write-dev-descriptor to serialize the dev module descriptor JSON.
+             Maven isolates plugin classpaths, so this does not leak into consuming builds. -->
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>

--- a/src/main/java/com/inductiveautomation/ignitionsdk/IgnitionModlMojo.java
+++ b/src/main/java/com/inductiveautomation/ignitionsdk/IgnitionModlMojo.java
@@ -359,7 +359,11 @@ public class IgnitionModlMojo extends AbstractMojo {
                 }
             }
 
+            Set<String> hookScopes = new HashSet<>();
             for (ModuleHook h : hooks) {
+                if (!hookScopes.add(h.getScope())) {
+                    throw new MojoExecutionException(h.getScope() + " has hookClass assigned already.");
+                }
                 writer.writeStartElement("hook");
                 writer.writeAttribute("scope", h.getScope());
                 writer.writeCharacters(h.getHookClass());

--- a/src/main/java/com/inductiveautomation/ignitionsdk/IgnitionModlMojo.java
+++ b/src/main/java/com/inductiveautomation/ignitionsdk/IgnitionModlMojo.java
@@ -115,8 +115,8 @@ public class IgnitionModlMojo extends AbstractMojo {
      * Specify if the module is a free module.  Defaults to false if not supplied.
      */
     @Deprecated
-    @Parameter(required = false, defaultValue = "false")
-    private String freeModule;
+    @Parameter(defaultValue = "false")
+    private boolean freeModule;
 
     /**
      * The name of the documentation index file.

--- a/src/main/java/com/inductiveautomation/ignitionsdk/IgnitionModlMojo.java
+++ b/src/main/java/com/inductiveautomation/ignitionsdk/IgnitionModlMojo.java
@@ -322,9 +322,14 @@ public class IgnitionModlMojo extends AbstractMojo {
             }
 
             if (depends != null) {
+                // The 'required' attribute is only understood by Ignition 8.3+; emit it only then.
+                boolean writeRequired = IgnitionVersions.supportsRequiredDependencyFlag(requiredIgnitionVersion);
                 for (ModuleDepends d : depends) {
                     writer.writeStartElement("depends");
                     writer.writeAttribute("scope", d.getScope());
+                    if (writeRequired) {
+                        writer.writeAttribute("required", String.valueOf(d.isRequired()));
+                    }
                     writer.writeCharacters(d.getModuleId());
                     writer.writeEndElement();
                 }

--- a/src/main/java/com/inductiveautomation/ignitionsdk/IgnitionVersions.java
+++ b/src/main/java/com/inductiveautomation/ignitionsdk/IgnitionVersions.java
@@ -1,0 +1,37 @@
+package com.inductiveautomation.ignitionsdk;
+
+/**
+ * Helpers for reasoning about the {@code requiredIgnitionVersion} of a module.
+ */
+final class IgnitionVersions {
+
+    private IgnitionVersions() {
+    }
+
+    /**
+     * Whether the given required Ignition version supports the {@code required} flag on module
+     * dependencies (Ignition 8.3+). Mirrors the Gradle plugin's {@code usemoduleDependencySpecs()}
+     * so the two build plugins gate the flag identically.
+     *
+     * @param requiredIgnitionVersion the configured minimum Ignition version (e.g. {@code "8.3.0"})
+     * @return {@code true} if the version is 8.3 or newer, {@code false} otherwise (including null,
+     *     empty, or unparseable versions)
+     */
+    static boolean supportsRequiredDependencyFlag(String requiredIgnitionVersion) {
+        if (requiredIgnitionVersion == null || requiredIgnitionVersion.isEmpty()) {
+            return false;
+        }
+
+        String[] parts = requiredIgnitionVersion.split("\\.");
+        try {
+            int major = Integer.parseInt(parts[0]);
+            if (major >= 2027) {
+                return true;
+            }
+            int minor = parts.length > 1 ? Integer.parseInt(parts[1]) : 0;
+            return major == 8 && minor >= 3;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/inductiveautomation/ignitionsdk/ModuleDepends.java
+++ b/src/main/java/com/inductiveautomation/ignitionsdk/ModuleDepends.java
@@ -4,6 +4,7 @@ public class ModuleDepends {
 
     private String scope;
     private String moduleId;
+    private boolean required;
 
     public String getScope() {
         return scope;
@@ -13,12 +14,20 @@ public class ModuleDepends {
         return moduleId;
     }
 
+    public boolean isRequired() {
+        return required;
+    }
+
     public void setScope(String scope) {
         this.scope = scope;
     }
 
     public void setModuleId(String moduleId) {
         this.moduleId = moduleId;
+    }
+
+    public void setRequired(boolean required) {
+        this.required = required;
     }
 
 }

--- a/src/main/java/com/inductiveautomation/ignitionsdk/WriteDevDescriptorMojo.java
+++ b/src/main/java/com/inductiveautomation/ignitionsdk/WriteDevDescriptorMojo.java
@@ -63,8 +63,8 @@ public class WriteDevDescriptorMojo extends AbstractMojo {
     @Parameter(defaultValue = "${project.version}", required = true)
     private String moduleVersion;
 
-    @Parameter(required = false, defaultValue = "false")
-    private String freeModule;
+    @Parameter(defaultValue = "false")
+    private boolean freeModule;
 
     @Parameter(required = true)
     private String requiredIgnitionVersion;
@@ -132,7 +132,7 @@ public class WriteDevDescriptorMojo extends AbstractMojo {
         descriptor.put("id", moduleId);
         descriptor.put("name", moduleName);
         descriptor.put("version", moduleVersion);
-        descriptor.put("freeModule", Boolean.parseBoolean(freeModule));
+        descriptor.put("freeModule", freeModule);
 
         // Hooks: scope -> className
         Map<String, String> hooksMap = new LinkedHashMap<>();

--- a/src/main/java/com/inductiveautomation/ignitionsdk/WriteDevDescriptorMojo.java
+++ b/src/main/java/com/inductiveautomation/ignitionsdk/WriteDevDescriptorMojo.java
@@ -127,7 +127,7 @@ public class WriteDevDescriptorMojo extends AbstractMojo {
         if (hooks != null) {
             for (ModuleHook hook : hooks) {
                 if (hooksMap.containsKey(hook.getScope())){
-                    throw Exception(hook.getScope() + " has hookClass assigned already.")
+                    throw new MojoExecutionException(hook.getScope() + " has hookClass assigned already.");
                 }
                 hooksMap.put(hook.getScope(), hook.getHookClass());
             }

--- a/src/main/java/com/inductiveautomation/ignitionsdk/WriteDevDescriptorMojo.java
+++ b/src/main/java/com/inductiveautomation/ignitionsdk/WriteDevDescriptorMojo.java
@@ -20,6 +20,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -83,6 +84,12 @@ public class WriteDevDescriptorMojo extends AbstractMojo {
         // Collect scope data from sub-projects
         Map<String, ScopeData> scopeMap = new LinkedHashMap<>();
 
+        // Reactor modules (by groupId:artifactId) — their jars are excluded; we use class dirs instead.
+        Set<String> reactorModuleIds = new HashSet<>();
+        for (MavenProject mp : parent.getCollectedProjects()) {
+            reactorModuleIds.add(mp.getGroupId() + ":" + mp.getArtifactId());
+        }
+
         for (MavenProject p : parent.getCollectedProjects()) {
             String scope = ignitionScopes.get(p.getName());
             if (scope == null) {
@@ -103,14 +110,20 @@ public class WriteDevDescriptorMojo extends AbstractMojo {
                 data.classDirs.add(targetClasses.getAbsolutePath());
             }
 
-            // Resolved dependency JARs (compile scope, external only)
+            // Resolved dependency JARs — mirror the set that ignition:modl bundles into the .modl:
+            // only compile-scoped third-party artifacts. The artifact filter must be set for a
+            // collected (sibling) project's getArtifacts() to return anything (same as IgnitionModlMojo).
             p.setArtifactFilter(new ScopeArtifactFilter("compile"));
             for (Artifact artifact : p.getArtifacts()) {
+                if (!"compile".equals(artifact.getScope())) {
+                    continue;
+                }
+                // Exclude reactor project artifacts (other sub-modules) — we use class dirs for those.
+                if (reactorModuleIds.contains(artifact.getGroupId() + ":" + artifact.getArtifactId())) {
+                    continue;
+                }
                 if (artifact.getFile() != null && artifact.getFile().getName().endsWith(".jar")) {
-                    // Exclude project artifacts (other sub-modules) — we use class dirs for those
-                    if (artifact.getScope() != null) {
-                        data.jars.add(artifact.getFile().getAbsolutePath());
-                    }
+                    data.jars.add(artifact.getFile().getAbsolutePath());
                 }
             }
         }

--- a/src/main/java/com/inductiveautomation/ignitionsdk/WriteDevDescriptorMojo.java
+++ b/src/main/java/com/inductiveautomation/ignitionsdk/WriteDevDescriptorMojo.java
@@ -1,0 +1,179 @@
+package com.inductiveautomation.ignitionsdk;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.resolver.filter.ScopeArtifactFilter;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.StringUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Generates a JSON dev module descriptor for IDE classloader isolation.
+ * <p>
+ * The descriptor contains module metadata (id, name, version, hooks, dependencies) along with
+ * per-scope class output directories and resolved dependency JAR paths. This enables a dev Ignition
+ * gateway to load the module directly from Maven build outputs instead of requiring a full .modl build.
+ * <p>
+ * Usage: {@code mvn ignition:write-dev-descriptor}
+ */
+@Mojo(name = "write-dev-descriptor",
+    defaultPhase = LifecyclePhase.COMPILE,
+    requiresDependencyResolution = ResolutionScope.COMPILE,
+    requiresDependencyCollection = ResolutionScope.COMPILE)
+public class WriteDevDescriptorMojo extends AbstractMojo {
+
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
+    @Parameter(defaultValue = "${project}", readonly = true)
+    private MavenProject project;
+
+    @Parameter(defaultValue = "${project.collectedProjects}", readonly = true)
+    private List<MavenProject> projects;
+
+    @Parameter(required = true)
+    private ProjectScope[] projectScopes;
+
+    @Parameter(required = true)
+    private String moduleId;
+
+    @Parameter(required = true)
+    private String moduleName;
+
+    @Parameter(defaultValue = "${project.version}", required = true)
+    private String moduleVersion;
+
+    @Parameter(required = false, defaultValue = "false")
+    private String freeModule;
+
+    @Parameter
+    private ModuleDepends[] depends;
+
+    @Parameter(required = true)
+    private ModuleHook[] hooks;
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        MavenProject parent = project.hasParent() ? project.getParent() : project;
+
+        // Build scope mapping: sub-project name -> scope letter(s)
+        Map<String, String> ignitionScopes = new HashMap<>();
+        for (ProjectScope ps : projectScopes) {
+            ignitionScopes.put(ps.getName(), ps.getScope());
+        }
+
+        // Collect scope data from sub-projects
+        Map<String, ScopeData> scopeMap = new LinkedHashMap<>();
+
+        for (MavenProject p : parent.getCollectedProjects()) {
+            String scope = ignitionScopes.get(p.getName());
+            if (scope == null) {
+                continue;
+            }
+
+            ScopeData data = scopeMap.computeIfAbsent(scope, k -> new ScopeData());
+
+            // Class output directory (Maven convention: target/classes)
+            String outputDir = p.getBuild().getOutputDirectory();
+            if (outputDir != null && new File(outputDir).isDirectory()) {
+                data.classDirs.add(outputDir);
+            }
+
+            // Resources output (same dir in Maven, but check for target/classes explicitly)
+            File targetClasses = new File(p.getBasedir(), "target/classes");
+            if (targetClasses.isDirectory()) {
+                data.classDirs.add(targetClasses.getAbsolutePath());
+            }
+
+            // Resolved dependency JARs (compile scope, external only)
+            p.setArtifactFilter(new ScopeArtifactFilter("compile"));
+            for (Artifact artifact : p.getArtifacts()) {
+                if (artifact.getFile() != null && artifact.getFile().getName().endsWith(".jar")) {
+                    // Exclude project artifacts (other sub-modules) — we use class dirs for those
+                    if (artifact.getScope() != null) {
+                        data.jars.add(artifact.getFile().getAbsolutePath());
+                    }
+                }
+            }
+        }
+
+        // Build the descriptor
+        Map<String, Object> descriptor = new LinkedHashMap<>();
+        descriptor.put("id", moduleId);
+        descriptor.put("name", moduleName);
+        descriptor.put("version", moduleVersion);
+        descriptor.put("freeModule", Boolean.parseBoolean(freeModule));
+
+        // Hooks: scope -> className
+        Map<String, String> hooksMap = new LinkedHashMap<>();
+        if (hooks != null) {
+            for (ModuleHook hook : hooks) {
+                if (hooksMap.containsKey(hook.getScope())){
+                    throw Exception(hook.getScope() + " has hookClass assigned already.")
+                }
+                hooksMap.put(hook.getScope(), hook.getHookClass());
+            }
+        }
+        descriptor.put("hooks", hooksMap);
+
+        // Module dependencies
+        List<Map<String, Object>> depsList = new ArrayList<>();
+        if (depends != null) {
+            for (ModuleDepends dep : depends) {
+                Map<String, Object> depMap = new LinkedHashMap<>();
+                depMap.put("id", dep.getModuleId());
+                depMap.put("scope", dep.getScope());
+                depMap.put("required", true);
+                depsList.add(depMap);
+            }
+        }
+        descriptor.put("moduleDependencies", depsList);
+
+        // Scopes
+        Map<String, Map<String, Set<String>>> scopesJson = new LinkedHashMap<>();
+        for (Map.Entry<String, ScopeData> entry : scopeMap.entrySet()) {
+            Map<String, Set<String>> scopeEntry = new LinkedHashMap<>();
+            scopeEntry.put("classDirs", entry.getValue().classDirs);
+            scopeEntry.put("jars", entry.getValue().jars);
+            scopesJson.put(entry.getKey(), scopeEntry);
+        }
+        descriptor.put("scopes", scopesJson);
+
+        descriptor.put("exports", new LinkedHashMap<>());
+
+        // Write to build/dev/{moduleId}.json
+        Path outputDir = Path.of(project.getBuild().getDirectory(), "dev");
+        Path outputFile = outputDir.resolve(moduleId + ".json");
+
+        try {
+            Files.createDirectories(outputDir);
+            Files.writeString(outputFile, GSON.toJson(descriptor), StandardCharsets.UTF_8);
+            getLog().info("Wrote dev module descriptor: " + outputFile.toAbsolutePath());
+        } catch (IOException e) {
+            throw new MojoExecutionException("Failed to write dev module descriptor", e);
+        }
+    }
+
+    private static class ScopeData {
+        final Set<String> classDirs = new LinkedHashSet<>();
+        final Set<String> jars = new LinkedHashSet<>();
+    }
+}

--- a/src/main/java/com/inductiveautomation/ignitionsdk/WriteDevDescriptorMojo.java
+++ b/src/main/java/com/inductiveautomation/ignitionsdk/WriteDevDescriptorMojo.java
@@ -34,6 +34,10 @@ import java.util.Set;
  * per-scope class output directories and resolved dependency JAR paths. This enables a dev Ignition
  * gateway to load the module directly from Maven build outputs instead of requiring a full .modl build.
  * <p>
+ * The descriptor references each subproject's {@code target/classes}, so the module must be compiled
+ * first. Run it after compilation — e.g. {@code mvn compile ignition:write-dev-descriptor}, or bind it
+ * to a post-compile phase — otherwise the class directories are omitted from the descriptor.
+ * <p>
  * Usage: {@code mvn ignition:write-dev-descriptor}
  */
 @Mojo(name = "write-dev-descriptor",
@@ -46,9 +50,6 @@ public class WriteDevDescriptorMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}", readonly = true)
     private MavenProject project;
-
-    @Parameter(defaultValue = "${project.collectedProjects}", readonly = true)
-    private List<MavenProject> projects;
 
     @Parameter(required = true)
     private ProjectScope[] projectScopes;
@@ -64,6 +65,9 @@ public class WriteDevDescriptorMojo extends AbstractMojo {
 
     @Parameter(required = false, defaultValue = "false")
     private String freeModule;
+
+    @Parameter(required = true)
+    private String requiredIgnitionVersion;
 
     @Parameter
     private ModuleDepends[] depends;
@@ -147,14 +151,18 @@ public class WriteDevDescriptorMojo extends AbstractMojo {
         }
         descriptor.put("hooks", hooksMap);
 
-        // Module dependencies
+        // Module dependencies. The 'required' flag is only understood by Ignition 8.3+, so gate it
+        // on requiredIgnitionVersion — same rule as the module.xml written by ignition:modl.
+        boolean writeRequired = IgnitionVersions.supportsRequiredDependencyFlag(requiredIgnitionVersion);
         List<Map<String, Object>> depsList = new ArrayList<>();
         if (depends != null) {
             for (ModuleDepends dep : depends) {
                 Map<String, Object> depMap = new LinkedHashMap<>();
                 depMap.put("id", dep.getModuleId());
                 depMap.put("scope", dep.getScope());
-                depMap.put("required", true);
+                if (writeRequired) {
+                    depMap.put("required", dep.isRequired());
+                }
                 depsList.add(depMap);
             }
         }
@@ -170,6 +178,8 @@ public class WriteDevDescriptorMojo extends AbstractMojo {
         }
         descriptor.put("scopes", scopesJson);
 
+        // TODO: exports are not yet collected; emitted as an empty object to match the descriptor
+        // schema (and the Gradle plugin's counterpart) until per-scope exports are wired up.
         descriptor.put("exports", new LinkedHashMap<>());
 
         // Write to build/dev/{moduleId}.json

--- a/src/main/java/com/inductiveautomation/ignitionsdk/WriteDevDescriptorMojo.java
+++ b/src/main/java/com/inductiveautomation/ignitionsdk/WriteDevDescriptorMojo.java
@@ -102,16 +102,11 @@ public class WriteDevDescriptorMojo extends AbstractMojo {
 
             ScopeData data = scopeMap.computeIfAbsent(scope, k -> new ScopeData());
 
-            // Class output directory (Maven convention: target/classes)
-            String outputDir = p.getBuild().getOutputDirectory();
-            if (outputDir != null && new File(outputDir).isDirectory()) {
-                data.classDirs.add(outputDir);
-            }
-
-            // Resources output (same dir in Maven, but check for target/classes explicitly)
-            File targetClasses = new File(p.getBasedir(), "target/classes");
-            if (targetClasses.isDirectory()) {
-                data.classDirs.add(targetClasses.getAbsolutePath());
+            // Class output directory (Maven convention: target/classes).
+            // Maven's resource plugin copies resources into this same dir, so it covers both.
+            File outDir = new File(p.getBuild().getOutputDirectory());
+            if (outDir.isDirectory()) {
+                data.classDirs.add(outDir.getAbsolutePath());
             }
 
             // Resolved dependency JARs — mirror the set that ignition:modl bundles into the .modl:


### PR DESCRIPTION
### 📖 Background
Running gateway in IntelliJ as a Gradle project will emit the following error:
java.lang.NoClassDefFoundError: javax/activation/DataSource

### ⚙️ Changes
JJ's [design document](https://docs.google.com/document/d/1mvTY5qcNzVGRRfWVkJYAg4XIIEhehPXhZRHFh0496BM/edit?tab=t.0#heading=h.t0m8ugbfaxp8)



Fixes: IGN-15978

